### PR TITLE
:put_litter_in_its_place: remove ACCESSORS const

### DIFF
--- a/lib/bu_pr/configuration.rb
+++ b/lib/bu_pr/configuration.rb
@@ -5,14 +5,12 @@ module BuPr
   class Configuration
     include Singleton
 
-    ACCESSORS = %i(
-      token
-      branch
-      title
-      repo
+    attr_accessor(
+      :branch,
+      :title,
+      :token,
+      :repo,
     )
-
-    attr_accessor(*ACCESSORS)
 
     # DEPRECATED
     alias access_token token
@@ -33,11 +31,25 @@ module BuPr
     end
 
     def valid?
-      ACCESSORS.all? do |accr|
-        val = public_send(accr)
+      token? && branch? && title? && repo?
+    end
 
-        val && val != ""
-      end
+    private
+
+    def token?
+      token && token != ""
+    end
+
+    def branch?
+      branch && branch != ""
+    end
+
+    def title?
+      title && title != ""
+    end
+
+    def repo?
+      repo && repo != ""
     end
   end
 end

--- a/spec/bu_pr/configuration_spec.rb
+++ b/spec/bu_pr/configuration_spec.rb
@@ -9,31 +9,22 @@ describe BuPr::Configuration do
     subject { config }
 
     it "responds to accessors" do
-      is_expected.to respond_to(:token)
-      is_expected.to respond_to(:token=)
-
-      # DEPRECATED
-      is_expected.to respond_to(:access_token)
-      is_expected.to respond_to(:access_token=)
-
       is_expected.to respond_to(:branch)
       is_expected.to respond_to(:branch=)
-
-      # DEPRECATED
-      is_expected.to respond_to(:base_branch)
-      is_expected.to respond_to(:base_branch=)
-
       is_expected.to respond_to(:title)
       is_expected.to respond_to(:title=)
-
-      # DEPRECATED
-      is_expected.to respond_to(:pr_title)
-      is_expected.to respond_to(:pr_title=)
-
+      is_expected.to respond_to(:token)
+      is_expected.to respond_to(:token=)
       is_expected.to respond_to(:repo)
       is_expected.to respond_to(:repo=)
 
       # DEPRECATED
+      is_expected.to respond_to(:access_token)
+      is_expected.to respond_to(:access_token=)
+      is_expected.to respond_to(:base_branch)
+      is_expected.to respond_to(:base_branch=)
+      is_expected.to respond_to(:pr_title)
+      is_expected.to respond_to(:pr_title=)
       is_expected.to respond_to(:repo_name)
       is_expected.to respond_to(:repo_name=)
     end


### PR DESCRIPTION
Avoid too match abstraction