### PR TITLE
Change CLI interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,51 +22,33 @@ Or install it yourself as:
 
 ## Usage
 
-Get Github access token from [this page](https://github.com/settings/tokens/new) with `repo` scope.
+Get GitHub access token from [this page](https://github.com/settings/tokens/new) with `repo` scope.
 
+then run
 
-### Set configuration values as Environment variables.
+```sh
+$ bundle exec bu_pr --repo=mmyoji/bu_pr --token=<the token you got above>
+```
+
+or you can just set `repo` and `token` values in your `$HOME/.profile` file.
 
 ```sh
 # .bash_profile / .profile / .zshrc / etc.
 
 export BUPR_TOKEN="xxx"
 export BUPR_REPO="mmyoji/bu_pr"
+
+# If you wanna override them:
 # export BUPR_BRANCH="develop"
 # export BUPR_TITLE="My bundle update"
 ```
 
+### Available options
 
-### Set configuration values in config file.
-
-```rb
-require 'bu_pr'
-
-# Setup
-BuPr.configure do |config|
-  config.token  = "xxx"              # Required
-  config.repo   = "mmyoji/bu_pr"     # Required
-
-  config.branch = "develop"          # Optional :: default is 'master'
-  config.title  = "My bundle update" # Optional :: default is like 'Bundle update 2016-11-13'
-end
-
-BuPr::Runner.call
-```
-
-### Rails
-
-```rb
-# config/initializers/bu_pr.rb
-
-BuPr.configure do |config|
-  config.token = "xxx"
-  config.repo  = "mmyoji/bu_pr"
-end
-```
-
-then run the command `rake bu_pr`
-
+* branch: base branch name for the pull-request. Default is `master`
+* repo: your github repository name
+* title: the pull-request title. Default is `Bundle update 2017-04-04`
+* token: your GitHub access token
 
 ## Contributing
 

--- a/bu_pr.gemspec
+++ b/bu_pr.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "compare_linker", "~> 1.1.0"
+  spec.add_dependency "thor", "~> 0.19"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/exe/bu_pr
+++ b/exe/bu_pr
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+
+require "bundler/setup"
+require "bu_pr"
+
+BuPr::Command.start(ARGV)

--- a/lib/bu_pr.rb
+++ b/lib/bu_pr.rb
@@ -7,11 +7,4 @@ require "bu_pr/runner"
 require "bu_pr/railtie" if defined?(Rails::Railtie)
 
 module BuPr
-  def configure
-    conf = Configuration.instance
-    yield conf
-
-    Runner.config = conf
-  end
-  module_function :configure
 end

--- a/lib/bu_pr.rb
+++ b/lib/bu_pr.rb
@@ -4,7 +4,4 @@ require "bu_pr/configuration"
 require "bu_pr/git"
 require "bu_pr/handlers/github"
 require "bu_pr/runner"
-require "bu_pr/railtie" if defined?(Rails::Railtie)
-
-module BuPr
-end
+require "bu_pr/command"

--- a/lib/bu_pr/command.rb
+++ b/lib/bu_pr/command.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require "thor"
+
+module BuPr
+  class Command < ::Thor
+    default_command :all
+
+    desc "all", "Run bundle update and create pull-request"
+    method_options(
+      branch: :string,
+      title:  :string,
+      token:  :string,
+      repo:   :string,
+    )
+    def all
+      Runner.call(options)
+    end
+  end
+end

--- a/lib/bu_pr/configuration.rb
+++ b/lib/bu_pr/configuration.rb
@@ -1,33 +1,21 @@
 # frozen_string_literal: true
-require 'singleton'
-
 module BuPr
   class Configuration
-    include Singleton
-
-    attr_accessor(
-      :branch,
-      :title,
-      :token,
-      :repo,
+    ATTRS = %i(
+      branch
+      title
+      token
+      repo
     )
 
-    # DEPRECATED
-    alias access_token token
-    alias access_token= token=
-    alias base_branch branch
-    alias base_branch= branch=
-    alias pr_title title
-    alias pr_title= title=
-    alias repo_name repo
-    alias repo_name= repo=
+    attr_accessor(*ATTRS)
 
-    def initialize
-      @branch = ENV.fetch("BUPR_BRANCH") { "master" }
-      @title  = ENV.fetch("BUPR_TITLE")  { "Bundle update #{Time.now.strftime('%F')}" }
+    def initialize opts = {}
+      @branch = opts.fetch(:branch) { ENV.fetch("BUPR_BRANCH") { "master" } }
+      @title  = opts.fetch(:title)  { ENV.fetch("BUPR_TITLE")  { default_title } }
 
-      @token  = ENV["BUPR_TOKEN"]
-      @repo   = ENV["BUPR_REPO"]
+      @token  = opts.fetch(:token) { ENV["BUPR_TOKEN"] }
+      @repo   = opts.fetch(:repo)  { ENV["BUPR_REPO"] }
     end
 
     def valid?
@@ -36,20 +24,15 @@ module BuPr
 
     private
 
-    def token?
-      token && token != ""
+    ATTRS.each do |attr|
+      define_method "#{attr}?" do
+        v = public_send(attr)
+        !v.nil? && v != ""
+      end
     end
 
-    def branch?
-      branch && branch != ""
-    end
-
-    def title?
-      title && title != ""
-    end
-
-    def repo?
-      repo && repo != ""
+    def default_title
+      "Bundle update #{Time.now.strftime('%F')}"
     end
   end
 end

--- a/lib/bu_pr/railtie.rb
+++ b/lib/bu_pr/railtie.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module BuPr
-  class Railtie < ::Rails::Railtie
-    rake_tasks do
-      load "bu_pr/tasks/bu_pr.rake"
-    end
-  end
-end

--- a/lib/bu_pr/runner.rb
+++ b/lib/bu_pr/runner.rb
@@ -3,27 +3,23 @@
 module BuPr
   class Runner
     class << self
-      attr_writer :config
-
-      def config
-        @config ||= Configuration.instance
-      end
-
-      def call
-        new.call
+      def call opts = {}
+        new(opts).call
       end
     end
 
     attr_reader :git
+    attr_reader :config
 
-    def initialize
-      @git = Git.new
+    def initialize opts = {}
+      @git    = Git.new
+      @config = Configuration.new(opts)
     end
 
     def call
       if bundle_update && !git.diff?
         puts "no update"
-        exit
+        return
       end
 
       git.push
@@ -34,10 +30,6 @@ module BuPr
 
     def bundle_update
       valid? && _bundle_update
-    end
-
-    def config
-      self.class.config
     end
 
     def valid?

--- a/lib/bu_pr/tasks/bu_pr.rake
+++ b/lib/bu_pr/tasks/bu_pr.rake
@@ -1,4 +1,0 @@
-desc "Run bu_pr all tasks"
-task bu_pr: :environment do
-  BuPr::Runner.call
-end

--- a/spec/bu_pr/configuration_spec.rb
+++ b/spec/bu_pr/configuration_spec.rb
@@ -3,7 +3,8 @@ require "spec_helper"
 require_relative "./../../lib/bu_pr/configuration"
 
 describe BuPr::Configuration do
-  let(:config) { described_class.instance }
+  let(:opts)   { {} }
+  let(:config) { described_class.new(opts) }
 
   describe "attr_accessors" do
     subject { config }
@@ -17,16 +18,6 @@ describe BuPr::Configuration do
       is_expected.to respond_to(:token=)
       is_expected.to respond_to(:repo)
       is_expected.to respond_to(:repo=)
-
-      # DEPRECATED
-      is_expected.to respond_to(:access_token)
-      is_expected.to respond_to(:access_token=)
-      is_expected.to respond_to(:base_branch)
-      is_expected.to respond_to(:base_branch=)
-      is_expected.to respond_to(:pr_title)
-      is_expected.to respond_to(:pr_title=)
-      is_expected.to respond_to(:repo_name)
-      is_expected.to respond_to(:repo_name=)
     end
   end
 

--- a/spec/bu_pr/runner_spec.rb
+++ b/spec/bu_pr/runner_spec.rb
@@ -3,22 +3,25 @@ require "spec_helper"
 require_relative "./../../lib/bu_pr/runner"
 
 describe BuPr::Runner do
-  let(:config_double) { double("config", valid?: true) }
-
-  let(:runner) { described_class.new }
+  let(:opts) {
+    {
+      token: "xxx",
+      repo:  "mmyoji/bu_pr",
+    }
+  }
+  let(:runner) { described_class.new(opts) }
 
   describe "attr_reader" do
     subject { runner }
 
     it do
       is_expected.to respond_to :git
+      is_expected.to respond_to :config
     end
   end
 
   describe "#call" do
     before do
-      allow(runner).to receive(:config) { config_double }
-
       expect(runner).to receive(:bundle_update) { true }
     end
 
@@ -56,7 +59,6 @@ describe BuPr::Runner do
 
   describe '#bundle_update' do
     before do
-      allow(runner).to receive(:config) { config_double }
       allow(runner).to receive(:valid?) { validity }
     end
 
@@ -91,6 +93,8 @@ describe BuPr::Runner do
     subject { runner.valid? }
 
     context "w/ invalid config" do
+      let(:opts) { {} }
+
       specify do
         expect { subject }.to \
           raise_error(RuntimeError, "Invalid configuration")
@@ -99,7 +103,6 @@ describe BuPr::Runner do
 
     context "w/ git is not installed" do
       before do
-        expect(runner).to receive(:config) { config_double }
         expect(runner.git).to receive(:installed?) { false }
       end
 
@@ -111,7 +114,6 @@ describe BuPr::Runner do
 
     context "w/ valid setuo" do
       before do
-        expect(runner).to receive(:config) { config_double }
         expect(runner.git).to receive(:installed?) { true }
       end
 

--- a/spec/bu_pr_spec.rb
+++ b/spec/bu_pr_spec.rb
@@ -4,18 +4,4 @@ describe BuPr do
   it "has a version number" do
     expect(BuPr::VERSION).not_to be nil
   end
-
-  describe ".configure" do
-    specify do
-      described_class.configure do |c|
-        c.repo         = "mmyoji/bu_pr-test"
-        c.token = "xxx"
-      end
-
-      conf = described_class::Runner.config
-
-      expect(conf.repo).to eq "mmyoji/bu_pr-test"
-      expect(conf.token).to eq "xxx"
-    end
-  end
 end


### PR DESCRIPTION
Close #28 , #21 

I just found that I should use `exe/` (or `bin/`) directory for CLI.
Then use `thor` gem and change the interface.

Also remove deprecated APIs(methods).